### PR TITLE
Add prod approval gate after int

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -30,7 +30,8 @@ extends:
     service_name: ${{ variables.service_name }} 
     short_service_name: ${{ variables.short_service_name }} 
     service_base_path: ${{ variables.service_base_path }}
-    prod_producer_approval: true
+    prod_requires_approval: false
+    manual_approval_env: ${{ variables.service_name }}
     apigee_deployments:
       - environment: internal-dev
         post_deploy:
@@ -40,6 +41,10 @@ extends:
       - environment: int
         depends_on:
           - internal_dev
-      - environment: prod
+      - environment: manual-approval
+        stage_name: prod_approval
         depends_on:
           - int
+      - environment: prod
+        depends_on:
+          - prod_approval


### PR DESCRIPTION
﻿## Summary

Adds an explicit manual approval stage between `int` and `prod` in the release pipeline.

This prevents the production deployment from starting immediately after the existing non-prod stages and makes the intended release order:

1. `internal-dev`
2. `int`
3. `prod_approval`
4. `prod`

## Validation

- Confirmed the branch diff against `origin/master` contains only `azure/azure-release-pipeline.yml`.
- Ran `git diff --check origin/master..HEAD -- azure/azure-release-pipeline.yml`.
- Parsed `azure/azure-release-pipeline.yml` with `PyYAML` from the repo virtualenv.
- Asserted the release deployment graph locally:
  - `int` depends on `internal_dev`
  - `prod_approval` depends on `int`
  - `prod` depends on `prod_approval`
  - the template auto prod approval is disabled with `prod_requires_approval: false`
- Checked the shared `NHSDigital/api-management-utils` `edge` templates support explicit `manual-approval` deployments and pass through `manual_approval_env` and `depends_on`.

Azure still needs to validate the full server-side template expansion on the PR.
